### PR TITLE
Malformed URI from getCartPermalink()

### DIFF
--- a/MobileBuy/sample/src/main/java/com/shopify/sample/application/SampleApplication.java
+++ b/MobileBuy/sample/src/main/java/com/shopify/sample/application/SampleApplication.java
@@ -232,7 +232,7 @@ public class SampleApplication extends Application {
 
     public String getCartPermalink() {
         Uri.Builder uri = new Uri.Builder();
-        uri.scheme("http").path(buyClient.getShopDomain()).appendPath("cart");
+        uri.scheme("http").authority(buyClient.getShopDomain()).appendPath("cart");
 
         StringBuilder lineItemsStr = new StringBuilder();
         String prefix = "";


### PR DESCRIPTION
`getCartPermalink()` specified the shop domain as its `path` component instead of `authority`.

This results in a malformed URI for cart permalink, i.e.: `http:/domain.myshopify.com/cart?...`

After the change: `http://domain.myshopify.com/cart?...`

For reference from https://developer.android.com/reference/android/net/Uri.Builder.html#authority(java.lang.String):

> An absolute hierarchical URI reference follows the pattern: `<scheme>://<authority><absolute path>?<query>#<fragment>`
